### PR TITLE
Set utf-8 encoding for reading the logo

### DIFF
--- a/play.py
+++ b/play.py
@@ -75,7 +75,7 @@ def play_aidungeon_2():
     story_manager = UnconstrainedStoryManager(generator)
     print("\n")
 
-    with open('opening.txt', 'r') as file:
+    with open('opening.txt', 'r', encoding='utf-8') as file:
         starter = file.read()
     print(starter)
 


### PR DESCRIPTION
This appears primarily in Windows CLIs, see #48.
Also `termios` is not supported on Windows, however I haven't yet looked into an alternative.