### PR TITLE
More robust install.sh

### DIFF
--- a/generator/gpt2/models/.gitignore
+++ b/generator/gpt2/models/.gitignore
@@ -1,2 +1,0 @@
-*
-!.gitignore

--- a/install.sh
+++ b/install.sh
@@ -12,7 +12,7 @@ BASE_DIR="$(pwd)"
 MODELS_DIRECTORY=generator/gpt2/models
 MODEL_VERSION=model_v5
 MODEL_NAME=model-550
-MODEL_TORRENT_URL="https://github.com/nickwalton/AIDungeon/files/3935881/model_v5.torrent.zip"
+MODEL_TORRENT_URL="https://github.com/AIDungeon/AIDungeon/files/3935881/model_v5.torrent.zip"
 MODEL_TORRENT_BASENAME="$(basename "${MODEL_TORRENT_URL}")"
 
 pip_install () {

--- a/install.sh
+++ b/install.sh
@@ -16,7 +16,6 @@ MODEL_TORRENT_URL="https://github.com/nickwalton/AIDungeon/files/3935881/model_v
 MODEL_TORRENT_BASENAME="$(basename "${MODEL_TORRENT_URL}")"
 
 pip_install () {
-
 	if [ "$PYTHON_VER" != "3.6" ]; then 
 		echo "One of the packages 'Tensorflow 1.15' only supports Python 3.6.x"
 		echo "Your default Python installation is $PYTHON_VER.x."
@@ -34,15 +33,11 @@ pip_install () {
 		sudo ${PIP36} install --upgrade pip setuptools
 		sudo ${PIP36} install -r $BASE_DIR/requirements.txt
 	fi
-
 	echo "Once everything is installed, play the game with 'python3.6 ./play.py'"
 	exit
-
 }
 
-
 aid_install () {
-
 	echo "Determining package manager."
 	for f in ${!OS_INFO[@]}
 	do
@@ -51,7 +46,6 @@ aid_install () {
 			PACKAGE_MANAGER=${OS_INFO[$f]}
 		fi
 	done
-
 	if [ -z "$PACKAGE_MANAGER" ]; then
 		echo "You do not seem to be using a supported package manager."
 		echo "Please make sure ${PACKAGES[@]} are installed then press [ENTER]"
@@ -59,37 +53,39 @@ aid_install () {
 	else
 		sudo ${PACKAGE_MANAGER} ${PACKAGES[@]}
 	fi
-
-
-
 	echo "Creating directories."
 	mkdir -p "${MODELS_DIRECTORY}"
 	cd "${MODELS_DIRECTORY}"
 	mkdir "${MODEL_VERSION}"
 	wget "${MODEL_TORRENT_URL}"
 	unzip "${MODEL_TORRENT_BASENAME}"
-	echo -e "\n\n==========================================="
-	echo "We are now starting to download the model."
-	echo "It will take a while to get up to speed."
-	echo "DHT errors are normal."
-	echo -e "===========================================\n"
-	aria2c \
-		--max-connection-per-server 16 \
-		--split 64 \
-		--bt-max-peers 500 \
-		--seed-time=0 \
-		--summary-interval=15 \
-		--disable-ipv6 \
-		"${MODEL_TORRENT_BASENAME%.*}"
-	echo "Download Complete!"
-
-	pip_install
-							
+	which aria2c > /dev/null
+	if [ $? == 0 ]; then
+		echo -e "\n\n==========================================="
+		echo "We are now starting to download the model."
+		echo "It will take a while to get up to speed."
+		echo "DHT errors are normal."
+		echo -e "===========================================\n"
+		aria2c \
+			--max-connection-per-server 16 \
+			--split 64 \
+			--bt-max-peers 500 \
+			--seed-time=0 \
+			--summary-interval=15 \
+			--disable-ipv6 \
+			"${MODEL_TORRENT_BASENAME%.*}"
+		echo "Download Complete!"
+		pip_install
+	else
+		echo "aria2c isn't available in PATH."
+		echo "Exiting."
+		exit
+	fi
 }
 
 reinstall () {
-	echo "Deleting ./generator/*"
-	rm -r ./generator
+	echo "Deleting $MODELS_DIRECTORY"
+	rm -rf ${MODELS_DIRECTORY}
 	aid_install
 }
 
@@ -100,7 +96,6 @@ if [[ -d "${MODELS_DIRECTORY}/${MODEL_VERSION}" ]]; then
 	echo "Warning, this will delete some files![y/N]"
 	read ANSWER
 	ANSWER=$(echo $ANSWER | tr '[:upper:]' '[:lower:]')
-
 	case $ANSWER in
 		"yes")
 			reinstall;;

--- a/install.sh
+++ b/install.sh
@@ -1,38 +1,115 @@
 #!/bin/bash
 cd "$(dirname "${0}")"
+declare -A OS_INFO;
+OS_INFO[/etc/debian_version]="apt-get install"
+OS_INFO[/etc/alpine-release]="apk --update add"
+OS_INFO[/etc/centos-release]="yum install"
+OS_INFO[/etc/fedora-release]="dnf install"
+OS_INFO[/etc/arch-release]="pacman -S"
+PYTHON_VER=$(python --version | sed -En "s/Python //p" | cut -c1-3)
+PACKAGES=(aria2 git unzip wget)
 BASE_DIR="$(pwd)"
-
 MODELS_DIRECTORY=generator/gpt2/models
 MODEL_VERSION=model_v5
 MODEL_NAME=model-550
 MODEL_TORRENT_URL="https://github.com/nickwalton/AIDungeon/files/3935881/model_v5.torrent.zip"
 MODEL_TORRENT_BASENAME="$(basename "${MODEL_TORRENT_URL}")"
 
+pip_install () {
+
+	if [ "$PYTHON_VER" != "3.6" ]; then 
+		echo "One of the packages 'Tensorflow 1.15' only supports Python 3.6.x"
+		echo "Your default Python installation is $PYTHON_VER.x."
+		echo "You'll need to install Python 3.6 manually and then do"
+		echo "pip install -r ./requirements.txt"
+		echo "If you have 3.6 installed, please enter the full path of pip3.6."
+		echo "Leave blank to exit the installation."
+		read PIP36
+	else
+		PIP36=$(which pip)
+		 
+	fi
+	if [[ ! -z "$PIP36" ]]; then
+		echo "Installing Python packages."
+		sudo ${PIP36} install --upgrade pip setuptools
+		sudo ${PIP36} install -r $BASE_DIR/requirements.txt
+	fi
+
+	echo "Once everything is installed, play the game with 'python3.6 ./play.py'"
+	exit
+
+}
+
+
+aid_install () {
+
+	echo "Determining package manager."
+	for f in ${!OS_INFO[@]}
+	do
+		if [[ -f $f ]]; then
+			echo "Found $f."
+			PACKAGE_MANAGER=${OS_INFO[$f]}
+		fi
+	done
+
+	if [ -z "$PACKAGE_MANAGER" ]; then
+		echo "You do not seem to be using a supported package manager."
+		echo "Please make sure ${PACKAGES[@]} are installed then press [ENTER]"
+		read NOT_USED
+	else
+		sudo ${PACKAGE_MANAGER} ${PACKAGES[@]}
+	fi
+
+
+
+	echo "Creating directories."
+	mkdir -p "${MODELS_DIRECTORY}"
+	cd "${MODELS_DIRECTORY}"
+	mkdir "${MODEL_VERSION}"
+	wget "${MODEL_TORRENT_URL}"
+	unzip "${MODEL_TORRENT_BASENAME}"
+	echo -e "\n\n==========================================="
+	echo "We are now starting to download the model."
+	echo "It will take a while to get up to speed."
+	echo "DHT errors are normal."
+	echo -e "===========================================\n"
+	aria2c \
+		--max-connection-per-server 16 \
+		--split 64 \
+		--bt-max-peers 500 \
+		--seed-time=0 \
+		--summary-interval=15 \
+		--disable-ipv6 \
+		"${MODEL_TORRENT_BASENAME%.*}"
+	echo "Download Complete!"
+
+	pip_install
+							
+}
+
+reinstall () {
+	echo "Deleting ./generator/*"
+	rm -r ./generator
+	aid_install
+}
+
 if [[ -d "${MODELS_DIRECTORY}/${MODEL_VERSION}" ]]; then
-    echo "AIDungeon2 is already installed"
-else
-    echo "Installing dependencies"
-    pip install -r requirements.txt > /dev/null
-    apt-get install aria2 unzip > /dev/null
-    
-    echo "Downloading AIDungeon2 Model... (this may take a very, very long time)"
-    mkdir -p "${MODELS_DIRECTORY}"
-    cd "${MODELS_DIRECTORY}"
-    mkdir "${MODEL_VERSION}"
-    wget "${MODEL_TORRENT_URL}"
-    unzip "${MODEL_TORRENT_BASENAME}"
-    echo -e "\n\n==========================================="
-    echo "We are now starting to download the model."
-    echo "It will take a while to get up to speed."
-    echo "DHT errors are normal."
-    echo -e "===========================================\n"
-    aria2c \
-        --max-connection-per-server 16 \
-        --split 64 \
-        --bt-max-peers 500 \
-        --seed-time=0 \
-        --summary-interval=15 \
-        --disable-ipv6 \
-        "${MODEL_TORRENT_BASENAME%.*}"
-    echo "Download Complete!"
+	ANSWER="n"
+	echo "AIDungeon2 is appears to be installed."
+	echo "Would you like to reinstall?"
+	echo "Warning, this will delete some files![y/N]"
+	read ANSWER
+	ANSWER=$(echo $ANSWER | tr '[:upper:]' '[:lower:]')
+
+	case $ANSWER in
+		"yes")
+			reinstall;;
+		"y")
+			reinstall;;
+		*)
+			echo "Exiting program!"
+			exit;;
+	esac
 fi
+
+aid_install


### PR DESCRIPTION
The ./install.sh is pretty lacking and requires a lot of user intervention. I've tried to make it more robust and support several Linux distros other than Ubuntu/Debian.

I'm currently using EndeavourOS (Arch based) and we're on Python 3.8. Tensorflow 1.15 only works up to Python 3.6.

Because of this, I added a check to see what version of Python you're on. If you're not on 3.6 it'll ask you to manually install it (no way I was going to try to manage that.) or it allows you to enter a manual path for pip3.6.

Also during my testing, it was annoying that the script just assumed I didn't have any problems if it found ./generator/gpt2/models so now it asks if you want to reinstall.

I've tested this script in several different ways and it has passed all of my tests, but I don't have any other distros installed to try it out on.

I'm not going to pretend I'm a Bash wizard so any feed back is appreciated.