### PR TITLE
Separate download torrent from install script

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 - Made `install.sh` more robust.
 - Sorted imports.
+- Split the model downloading script into `download_model.sh` from `install.sh`
 
 ## [2.0.0] - 2019-12-05
 

--- a/README.md
+++ b/README.md
@@ -15,7 +15,6 @@ cd AIDungeon
 python3 play.py
 ```
 
-
 Community
 ------------------------
 

--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@ To play the game locally, it is recommended that you have an nVidia GPU with 12 
 git clone https://github.com/AIDungeon/AIDungeon/
 cd AIDungeon
 ./install.sh
+./download_model.sh
 python3 play.py
 ```
 

--- a/download_model.sh
+++ b/download_model.sh
@@ -1,0 +1,59 @@
+#!/bin/bash
+cd "$(dirname "${0}")"
+BASE_DIR="$(pwd)"
+
+BASE_DIR="$(pwd)"
+MODELS_DIRECTORY=generator/gpt2/models
+MODEL_VERSION=model_v5
+
+MODEL_DIRECTORY="${MODELS_DIRECTORY}/${MODEL_VERSION}"
+
+MODEL_NAME=model-550
+MODEL_TORRENT_URL="https://github.com/AIDungeon/AIDungeon/files/3935881/model_v5.torrent.zip"
+MODEL_TORRENT_BASENAME="$(basename "${MODEL_TORRENT_URL}")"
+
+download_torrent() {
+  echo "Creating directories."
+  mkdir -p "${MODEL_DIRECTORY}"
+  cd "${MODEL_DIRECTORY}"
+  wget "${MODEL_TORRENT_URL}"
+  unzip "${MODEL_TORRENT_BASENAME}"
+  which aria2c > /dev/null
+  if [ $? == 0 ]; then
+    echo -e "\n\n==========================================="
+    echo "We are now starting to download the model."
+    echo "It will take a while to get up to speed."
+    echo "DHT errors are normal."
+    echo -e "===========================================\n"
+    aria2c \
+      --max-connection-per-server 16 \
+      --split 64 \
+      --bt-max-peers 500 \
+      --seed-time=0 \
+      --summary-interval=15 \
+      --disable-ipv6 \
+      "${MODEL_TORRENT_BASENAME%.*}"
+    echo "Download Complete!"
+}
+
+redownload () {
+	echo "Deleting $MODEL_DIRECTORY"
+	rm -rf ${MODEL_DIRECTORY}
+	download_torrent
+}
+
+if [[ -d "${MODEL_DIRECTORY}" ]]; then
+	ANSWER="n"
+	echo "AIDungeon2 Model appears to be downloaded."
+	echo "Would you like to redownload?"
+	echo "WARNING: This will remove the current model![y/N]"
+	read ANSWER
+	ANSWER=$(echo $ANSWER | tr '[:upper:]' '[:lower:]')
+	case $ANSWER in
+		 [yY][eE][sS]|[yY]))
+			redownload;;
+		*)
+			echo "Exiting program!"
+			exit;;
+	esac
+fi

--- a/install.sh
+++ b/install.sh
@@ -1,5 +1,7 @@
 #!/bin/bash
 cd "$(dirname "${0}")"
+BASE_DIR="$(pwd)"
+
 declare -A OS_INFO;
 OS_INFO[/etc/debian_version]="apt-get install"
 OS_INFO[/etc/alpine-release]="apk --update add"
@@ -8,12 +10,6 @@ OS_INFO[/etc/fedora-release]="dnf install"
 OS_INFO[/etc/arch-release]="pacman -S"
 PYTHON_VER=$(python --version | sed -En "s/Python //p" | cut -c1-3)
 PACKAGES=(aria2 git unzip wget)
-BASE_DIR="$(pwd)"
-MODELS_DIRECTORY=generator/gpt2/models
-MODEL_VERSION=model_v5
-MODEL_NAME=model-550
-MODEL_TORRENT_URL="https://github.com/AIDungeon/AIDungeon/files/3935881/model_v5.torrent.zip"
-MODEL_TORRENT_BASENAME="$(basename "${MODEL_TORRENT_URL}")"
 
 pip_install () {
 	if [ "$PYTHON_VER" != "3.6" ]; then 
@@ -53,28 +49,6 @@ aid_install () {
 	else
 		sudo ${PACKAGE_MANAGER} ${PACKAGES[@]}
 	fi
-	echo "Creating directories."
-	mkdir -p "${MODELS_DIRECTORY}"
-	cd "${MODELS_DIRECTORY}"
-	mkdir "${MODEL_VERSION}"
-	wget "${MODEL_TORRENT_URL}"
-	unzip "${MODEL_TORRENT_BASENAME}"
-	which aria2c > /dev/null
-	if [ $? == 0 ]; then
-		echo -e "\n\n==========================================="
-		echo "We are now starting to download the model."
-		echo "It will take a while to get up to speed."
-		echo "DHT errors are normal."
-		echo -e "===========================================\n"
-		aria2c \
-			--max-connection-per-server 16 \
-			--split 64 \
-			--bt-max-peers 500 \
-			--seed-time=0 \
-			--summary-interval=15 \
-			--disable-ipv6 \
-			"${MODEL_TORRENT_BASENAME%.*}"
-		echo "Download Complete!"
 		pip_install
 	else
 		echo "aria2c isn't available in PATH."
@@ -82,29 +56,5 @@ aid_install () {
 		exit
 	fi
 }
-
-reinstall () {
-	echo "Deleting $MODELS_DIRECTORY"
-	rm -rf ${MODELS_DIRECTORY}
-	aid_install
-}
-
-if [[ -d "${MODELS_DIRECTORY}/${MODEL_VERSION}" ]]; then
-	ANSWER="n"
-	echo "AIDungeon2 is appears to be installed."
-	echo "Would you like to reinstall?"
-	echo "Warning, this will delete some files![y/N]"
-	read ANSWER
-	ANSWER=$(echo $ANSWER | tr '[:upper:]' '[:lower:]')
-	case $ANSWER in
-		"yes")
-			reinstall;;
-		"y")
-			reinstall;;
-		*)
-			echo "Exiting program!"
-			exit;;
-	esac
-fi
 
 aid_install


### PR DESCRIPTION
While trying to make the game more accessible, I found that coupling install and download model causes a lot of headache. This PR seeks to separate them so that user can pick the method they would like to get the model.