### PR TITLE
make winning/losing slightly easier and a little more robust

### DIFF
--- a/story/utils.py
+++ b/story/utils.py
@@ -59,6 +59,7 @@ def player_died(text):
         "you (die|pass away|perish|suffocate|drown|bleed out)",
         "you('ve| have) (died|perished|suffocated|drowned|been (killed|slain))",
         "you (\w* )?(yourself )?to death",
+        "you (\w* )*(collapse|bleed out|chok(e|ed|ing)|drown|dissolve) (\w* )*and (die(|d)|pass away|cease to exist|(\w* )+killed)",
     ]
     return any(re.search(regexp, lower_text) for regexp in you_dead_regexps)
 
@@ -68,8 +69,9 @@ def player_won(text):
     won_phrases = [
         "you live happily ever after",
         "you live (forever|eternally|for eternity)",
-        "you (are|become|turn into) (a)? (deity|god)",
+        "you (are|become|turn into) ((a|now) )?(deity|god|immortal)",
         "you ((go|get) (in)?to|arrive (at|in)) (heaven|paradise)",
+        "you celebrate your (victory|triumph)",
     ]
     return any(re.search(regexp, lower_text) for regexp in won_phrases)
 


### PR DESCRIPTION
Added a couple of regexes to match more win/loss conditions

The death regex that I added matches these:
```
you collapse under your own weight and die
you bleed out and die
you start choking and die
you get choked and die
you get choked and get killed
you bleed out and are killed
you dissolve and cease to exist
```

Also fixed one of the winning regexes so that these match:
```
you become immortal
you are now immortal
you become a god
```

Note, this is a redo of #106 targeting the correct branch