### PR TITLE
Adding utilities to backup stories to google Drive

### DIFF
--- a/AIDungeon_2.ipynb
+++ b/AIDungeon_2.ipynb
@@ -74,7 +74,8 @@
         "# Install\n",
         "!git clone --depth 1 --branch master https://github.com/AIDungeon/AIDungeon/\n",
         "%cd AIDungeon\n",
-        "!pip install -r requirements.txt > /dev/null"
+        "!pip install -r requirements.txt > /dev/null\n",
+        "print(\"Installation Complete!\")"
       ]
     },
     {
@@ -130,15 +131,15 @@
       },
       "outputs": [],
       "source": [
-        "# RUN THIS FIRST: Mount Google Drive\n",
+        "# RUN THIS FIRST before running any block below.\n",
+        "# This block mount Google Drive to our workspace \n",
+        "# so we can save to and load from it!\n",
+        "\n",
         "import pathlib\n",
         "from distutils.dir_util import copy_tree\n",
         "from google.colab import drive\n",
         "\n",
-        "try:\n",
-        "  drive.mount('/content/drive')\n",
-        "except:\n",
-        "  pass\n",
+        "drive.mount('/content/drive')\n",
         "\n",
         "drive_stories_directory=\"/content/drive/My Drive/AIDungeon/saved_stories\"\n",
         "collab_stories_directory=\"/content/AIDungeon/saved_stories\"\n",
@@ -159,11 +160,11 @@
       },
       "outputs": [],
       "source": [
-        "# Save stories to Google Drive\n",
+        "# Save stories to your Google Drive\n",
         "copy_tree(\n",
         "    collab_stories_directory, \n",
         "    drive_stories_directory\n",
-        ")\n"
+        ")"
       ]
     },
     {
@@ -176,10 +177,27 @@
       },
       "outputs": [],
       "source": [
-        "# Load from Google Drive\n",
+        "# Load stories from your Google Drive\n",
         "copy_tree(\n",
         "    drive_stories_directory, \n",
         "    collab_stories_directory\n",
+        ")"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": 0,
+      "metadata": {
+        "colab": {},
+        "colab_type": "code",
+        "id": "Ue0qY7mvKrZ0"
+      },
+      "outputs": [],
+      "source": [
+        "# Backup model from Collab to Google Drive. Requires 6.5GB of space!\n",
+        "copy_tree(\n",
+        "    collab_model_directory,\n",
+        "    drive_model_directory\n",
         ")"
       ]
     },
@@ -195,7 +213,6 @@
       "source": [
         "# Copy model from Google Drive. Make sure the model is uploaded to your personal Drive. \n",
         "# It should resides in a Data folder. The path is: /Data/model_v5/\n",
-        "\n",
         "copy_tree(\n",
         "    drive_model_directory, \n",
         "    collab_model_directory\n",
@@ -204,30 +221,23 @@
     },
     {
       "cell_type": "code",
-      "execution_count": 0,
-      "metadata": {
-        "colab": {},
-        "colab_type": "code",
-        "id": "Ue0qY7mvKrZ0"
-      },
-      "outputs": [],
-      "source": [
-        "# Backup model from Collab to Google Drive. Requires 6GB of space!\n",
-        "\n",
-        "copy_tree(\n",
-        "    collab_model_directory,\n",
-        "    drive_model_directory\n",
-        ")"
-      ]
-    },
-    {
-      "cell_type": "code",
       "execution_count": null,
       "metadata": {},
-      "outputs": [],
+      "outputs": [
+        {
+          "evalue": "Error: Jupyter cannot be started. Error attempting to locate jupyter: Error: Module 'notebook' not installed.",
+          "output_type": "error"
+        }
+      ],
       "source": [
-        "# If you get an OOM (out of memory error, random crashes) you might want to increase the available RAM. To do this, run the code below. Wait until it crashes and a little message pops up asking if you'd like to increase the available memory. Say yes and run the game.\n",
-        "# Credit goes to bpseudopod for figuring this out. View the post where that happened here: https://www.reddit.com/r/AIDungeon/comments/e782oi/tips_for_crash_prevention/\n",
+        "# If you get an OOM (out of memory error, random crashes) \n",
+        "# you might want to increase the available RAM. \n",
+        "\n",
+        "# To do so, run this block. Wait until it crashes\n",
+        "# and a little message will pops up asking if \n",
+        "# you'd like to increase the available memory. Say yes and run the game.\n",
+        "# Credit goes to bpseudopod for figuring this out.\n",
+        "# Source: https://www.reddit.com/r/AIDungeon/comments/e782oi/tips_for_crash_prevention/\n",
         "\n",
         "d = []\n",
         "while True:\n",

--- a/AIDungeon_2.ipynb
+++ b/AIDungeon_2.ipynb
@@ -4,7 +4,9 @@
   "metadata": {
     "colab": {
       "name": "AIDungeon 2.ipynb",
-      "provenance": []
+      "provenance": [],
+      "collapsed_sections": [],
+      "toc_visible": true
     },
     "kernelspec": {
       "name": "python3",
@@ -16,8 +18,8 @@
     {
       "cell_type": "markdown",
       "metadata": {
-        "id": "7dRi_BDWErNf",
-        "colab_type": "text"
+        "colab_type": "text",
+        "id": "pdmJ358wwzmv"
       },
       "source": [
         "![BYU PCCL](https://pcc4318.files.wordpress.com/2018/02/asset-1.png?w=150)\n",
@@ -36,49 +38,186 @@
         "\n",
         "## How to play\n",
         "1. Click \"Tools\"-> \"Settings...\" -> \"Theme\" -> \"Dark\" (optional but recommended)\n",
-        "2. Click \"Runtime\" -> \"Run all\"\n",
-        "3. Wait until all files are downloaded (only has to be one once, and it will take some time)\n",
-        "4. It will then take a couple minutes to boot up as the model is loaded onto the GPU. \n",
-        "5. If you have questions about getting it to work then please [go to github repo](https://github.com/AIDungeon/AIDungeon) to get help. \n",
+        "2. Go to **Main Game** section below\n",
+        "3. Run Install block\n",
+        "3. Run Download Model block \n",
+        "4. It will then take a couple minutes to boot up as the model is downloaded loaded onto the GPU. \n",
+        "5. Run the game block \n",
+        "6. If you have questions about getting it to work then please [go to github repo](https://github.com/AIDungeon/AIDungeon) to get help. \n",
         "\n",
         "## About\n",
         "* While you wait you can [read adventures others have had](https://aidungeon.io/)\n",
-        "* [Read more](https://pcc.cs.byu.edu/2019/11/21/ai-dungeon-2-creating-infinitely-generated-text-adventures-with-deep-learning-language-models/) about how AI Dungeon 2 is made.",
-        "- **[Support AI Dungeon 2](https://www.patreon.com/bePatron?u=19115449) on Patreon to help me to continue improving the game with all the awesome ideas I have for its future!**\n"
+        "* [Read more](https://pcc.cs.byu.edu/2019/11/21/ai-dungeon-2-creating-infinitely-generated-text-adventures-with-deep-learning-language-models/) about how AI Dungeon 2 is made.- **[Support AI Dungeon 2](https://www.patreon.com/bePatron?u=19115449) on Patreon to help me to continue improving the game with all the awesome ideas I have for its future!**"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "colab_type": "text",
+        "id": "pyNN-3UDv0L-"
+      },
+      "source": [
+        "# Main Game"
       ]
     },
     {
       "cell_type": "code",
+      "execution_count": 0,
       "metadata": {
-        "id": "FKqlSCrpS9dH",
+        "colab": {},
         "colab_type": "code",
-        "colab": {}
+        "id": "FKqlSCrpS9dH"
       },
+      "outputs": [],
       "source": [
+        "# Install\n",
         "!git clone --depth 1 --branch master https://github.com/AIDungeon/AIDungeon/\n",
         "%cd AIDungeon\n",
-        "!./install.sh\n",
-        "from IPython.display import clear_output \n",
-        "clear_output()\n",
-        "print(\"Download Complete!\")"
-      ],
-      "execution_count": 0,
-      "outputs": []
+        "!pip install -r requirements.txt > /dev/null"
+      ]
     },
     {
       "cell_type": "code",
+      "execution_count": 0,
       "metadata": {
-        "id": "YjArwbWh6XwN",
+        "colab": {},
         "colab_type": "code",
-        "colab": {}
+        "id": "fiywfTj--_Pe"
       },
+      "outputs": [],
       "source": [
+        "# Download model from torrent:\n",
+        "!./install.sh\n",
+        "from IPython.display import clear_output\n",
+        "clear_output()\n",
+        "print(\"Download Complete!\")"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": 0,
+      "metadata": {
+        "colab": {},
+        "colab_type": "code",
+        "id": "YjArwbWh6XwN"
+      },
+      "outputs": [],
+      "source": [
+        "# Play\n",
         "from IPython.display import Javascript\n",
         "display(Javascript('''google.colab.output.setIframeHeight(0, true, {maxHeight: 5000})'''))\n",
         "!python play.py"
-      ],
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "colab_type": "text",
+        "id": "kIldfwd8wjvT"
+      },
+      "source": [
+        "# Utilities (Persistent Save / Load)"
+      ]
+    },
+    {
+      "cell_type": "code",
       "execution_count": 0,
-      "outputs": []
+      "metadata": {
+        "colab": {},
+        "colab_type": "code",
+        "id": "zLx1yMu9wwBg"
+      },
+      "outputs": [],
+      "source": [
+        "# RUN THIS FIRST: Mount Google Drive\n",
+        "import pathlib\n",
+        "from distutils.dir_util import copy_tree\n",
+        "from google.colab import drive\n",
+        "\n",
+        "try:\n",
+        "  drive.mount('/content/drive')\n",
+        "except:\n",
+        "  pass\n",
+        "\n",
+        "drive_stories_directory=\"/content/drive/My Drive/AIDungeon/saved_stories\"\n",
+        "collab_stories_directory=\"/content/AIDungeon/saved_stories\"\n",
+        "\n",
+        "drive_model_directory=\"/content/drive/My Drive/Data/model_v5\"\n",
+        "collab_model_directory=\"/content/AIDungeon/generator/gpt2/models/model_v5\"\n",
+        "\n",
+        "pathlib.Path(drive_stories_directory).mkdir(parents=True, exist_ok=True) "
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": 0,
+      "metadata": {
+        "colab": {},
+        "colab_type": "code",
+        "id": "LWfm6q8tAbDB"
+      },
+      "outputs": [],
+      "source": [
+        "# Save stories to Google Drive\n",
+        "copy_tree(\n",
+        "    collab_stories_directory, \n",
+        "    drive_stories_directory\n",
+        ")\n"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": 0,
+      "metadata": {
+        "colab": {},
+        "colab_type": "code",
+        "id": "HK2DO1jFxnv6"
+      },
+      "outputs": [],
+      "source": [
+        "# Load from Google Drive\n",
+        "copy_tree(\n",
+        "    drive_stories_directory, \n",
+        "    collab_stories_directory\n",
+        ")"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": 0,
+      "metadata": {
+        "colab": {},
+        "colab_type": "code",
+        "id": "XqK7MXhG40Oa"
+      },
+      "outputs": [],
+      "source": [
+        "# Copy model from Google Drive. Make sure the model is uploaded to your personal Drive. \n",
+        "# It should resides in a Data folder. The path is: /Data/model_v5/\n",
+        "\n",
+        "copy_tree(\n",
+        "    drive_model_directory, \n",
+        "    collab_model_directory\n",
+        ")"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": 0,
+      "metadata": {
+        "colab": {},
+        "colab_type": "code",
+        "id": "Ue0qY7mvKrZ0"
+      },
+      "outputs": [],
+      "source": [
+        "# Backup model from Collab to Google Drive. Requires 6GB of space!\n",
+        "\n",
+        "copy_tree(\n",
+        "    collab_model_directory,\n",
+        "    drive_model_directory\n",
+        ")"
+      ]
     }
   ]
 }

--- a/AIDungeon_2.ipynb
+++ b/AIDungeon_2.ipynb
@@ -46,8 +46,9 @@
         "6. If you have questions about getting it to work then please [go to github repo](https://github.com/AIDungeon/AIDungeon) to get help. \n",
         "\n",
         "## About\n",
-        "* While you wait you can [read adventures others have had](https://aidungeon.io/)\n",
-        "* [Read more](https://pcc.cs.byu.edu/2019/11/21/ai-dungeon-2-creating-infinitely-generated-text-adventures-with-deep-learning-language-models/) about how AI Dungeon 2 is made.- **[Support AI Dungeon 2](https://www.patreon.com/bePatron?u=19115449) on Patreon to help me to continue improving the game with all the awesome ideas I have for its future!**"
+        "- While you wait you can [read adventures others have had](https://aidungeon.io/)\n",
+        "- [Read more](https://pcc.cs.byu.edu/2019/11/21/ai-dungeon-2-creating-infinitely-generated-text-adventures-with-deep-learning-language-models/) about how AI Dungeon 2 is made.\n",
+        "- **[Support AI Dungeon 2](https://www.patreon.com/bePatron?u=19115449) on Patreon to help me to continue improving the game with all the awesome ideas I have for its future!**"
       ]
     },
     {

--- a/AIDungeon_2.ipynb
+++ b/AIDungeon_2.ipynb
@@ -74,7 +74,7 @@
         "# Install\n",
         "!git clone --depth 1 --branch master https://github.com/AIDungeon/AIDungeon/\n",
         "%cd AIDungeon\n",
-        "!pip install -r requirements.txt > /dev/null\n",
+        "!./install.sh\n",
         "print(\"Installation Complete!\")"
       ]
     },
@@ -89,7 +89,7 @@
       "outputs": [],
       "source": [
         "# Download model from torrent:\n",
-        "!./install.sh\n",
+        "!./download_model.sh\n",
         "from IPython.display import clear_output\n",
         "clear_output()\n",
         "print(\"Download Complete!\")"

--- a/AIDungeon_2.ipynb
+++ b/AIDungeon_2.ipynb
@@ -116,7 +116,7 @@
         "id": "kIldfwd8wjvT"
       },
       "source": [
-        "# Utilities (Persistent Save / Load)"
+        "# Utilities (Persistent Save / Load, OOM Fix)"
       ]
     },
     {
@@ -217,6 +217,20 @@
         "    collab_model_directory,\n",
         "    drive_model_directory\n",
         ")"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {},
+      "outputs": [],
+      "source": [
+        "# If you get an OOM (out of memory error, random crashes) you might want to increase the available RAM. To do this, run the code below. Wait until it crashes and a little message pops up asking if you'd like to increase the available memory. Say yes and run the game.\n",
+        "# Credit goes to bpseudopod for figuring this out. View the post where that happened here: https://www.reddit.com/r/AIDungeon/comments/e782oi/tips_for_crash_prevention/\n",
+        "\n",
+        "d = []\n",
+        "while True:\n",
+        "    d.append(1)"
       ]
     }
   ]


### PR DESCRIPTION
Related issues:
+ closes #88 
+ closes #105 

To test, it is required to change the checkout to point to develop branch since master does not save stories into the `saved_stories` directory yet. (refers to #98 and #101)

This PR added the following utilities code block:

0. Mount gdrive
1. Backup stories from Collab instance to Gdrive
2. Restore stories from GDrive to Collab
3. Backup model from Collab to GDrive
4. Copy model from GDrive to Collab
5. Extra memory allocation (See below)

1 and 2 is an attemp at #88 while 3 and 4 attempts to solve #105 (since copy from gdrive is way faster. This can also be used to backup finetune model from collab as well)

This does not conflict with either #102 or #93.