### PR TITLE
Send user feedback when performing the censor command

### DIFF
--- a/play.py
+++ b/play.py
@@ -167,10 +167,18 @@ def play_aidungeon_2():
                 console_print(instructions())
 
             elif action == "censor off":
-                generator.censor = False
+                if generator.censor == False:
+                    console_print("Censor is already disabled.")
+                else:
+                    generator.censor = False
+                    console_print("Censor is now disabled.")
 
             elif action == "censor on":
-                generator.censor = True
+                if generator.censor == True:
+                    console_print("Censor is already enabled.")
+                else:
+                    generator.censor = True
+                    console_print("Censor is now enabled.")
 
             elif action == "save":
                 if upload_story:

--- a/play.py
+++ b/play.py
@@ -167,14 +167,14 @@ def play_aidungeon_2():
                 console_print(instructions())
 
             elif action == "censor off":
-                if generator.censor == False:
+                if not generator.censor:
                     console_print("Censor is already disabled.")
                 else:
                     generator.censor = False
                     console_print("Censor is now disabled.")
 
             elif action == "censor on":
-                if generator.censor == True:
+                if generator.censor:
                     console_print("Censor is already enabled.")
                 else:
                     generator.censor = True


### PR DESCRIPTION
When using the censor command no user feedback is given confirming it has been disabled/enabled. This patch simply sends the user feedback in a similar format to the other commands. 


Example of patch in testing:
![example](https://user-images.githubusercontent.com/3377659/70671882-6e23bd80-1c32-11ea-9025-e89dd423bff8.png)
