### PR TITLE
Denote commands with a /

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Sorted imports.
 - Split the model downloading script into `download_model.sh` from `install.sh`.
 - User commands are now case-insensitive.
+- User commands are now denoted with the prefix `/`.
 
 ## [2.0.0] - 2019-12-05
 

--- a/play.py
+++ b/play.py
@@ -146,7 +146,7 @@ def play_aidungeon_2():
         while True:
             sys.stdin.flush()
             action = input("> ").strip()
-            if action[0] == "/":
+            if len(action) > 0 and action[0] == "/":
                 split = action[1:].split(" ") # removes preceding slash
                 command = split[0].lower()
                 args = split[1:]

--- a/play.py
+++ b/play.py
@@ -87,14 +87,14 @@ def instructions():
     text += '\n Enter actions starting with a verb ex. "go to the tavern" or "attack the orc."'
     text += '\n To speak enter \'say "(thing you want to say)"\' or just "(thing you want to say)" '
     text += "\n\nThe following commands can be entered for any action: "
-    text += '\n  "revert"   Reverts the last action allowing you to pick a different action.'
-    text += '\n  "quit"     Quits the game and saves'
-    text += '\n  "restart"  Starts a new game and saves your current one'
-    text += '\n  "save"     Makes a new save of your game and gives you the save ID'
-    text += '\n  "load"     Asks for a save ID and loads the game if the ID is valid'
-    text += '\n  "print"    Prints a transcript of your adventure (without extra newline formatting)'
-    text += '\n  "help"     Prints these instructions again'
-    text += '\n  "censor off/on" to turn censoring off or on.'
+    text += '\n  "/revert"   Reverts the last action allowing you to pick a different action.'
+    text += '\n  "/quit"     Quits the game and saves'
+    text += '\n  "/restart"  Starts a new game and saves your current one'
+    text += '\n  "/save"     Makes a new save of your game and gives you the save ID'
+    text += '\n  "/load"     Asks for a save ID and loads the game if the ID is valid'
+    text += '\n  "/print"    Prints a transcript of your adventure (without extra newline formatting)'
+    text += '\n  "/help"     Prints these instructions again'
+    text += '\n  "/censor off/on" to turn censoring off or on.'
     return text
 
 
@@ -145,82 +145,86 @@ def play_aidungeon_2():
 
         while True:
             sys.stdin.flush()
-            action = input("> ")
-            if action.lower() == "restart":
-                rating = input("Please rate the story quality from 1-10: ")
-                rating_float = float(rating)
-                story_manager.story.rating = rating_float
-                break
+            action = input("> ").strip()
+            if action[0] == "/":
+                split = action[1:].split(" ") # removes preceding slash
+                command = split[0].lower()
+                args = split[1:]
+                if command == "restart":
+                    rating = input("Please rate the story quality from 1-10: ")
+                    rating_float = float(rating)
+                    story_manager.story.rating = rating_float
+                    break
 
-            elif action.lower() == "quit":
-                rating = input("Please rate the story quality from 1-10: ")
-                rating_float = float(rating)
-                story_manager.story.rating = rating_float
-                exit()
+                elif command == "quit":
+                    rating = input("Please rate the story quality from 1-10: ")
+                    rating_float = float(rating)
+                    story_manager.story.rating = rating_float
+                    exit()
 
-            elif action.lower() == "nosaving":
-                upload_story = False
-                story_manager.story.upload_story = False
-                console_print("Saving turned off.")
+                elif command == "nosaving":
+                    upload_story = False
+                    story_manager.story.upload_story = False
+                    console_print("Saving turned off.")
 
-            elif action.lower() == "help":
-                console_print(instructions())
+                elif command == "help":
+                    console_print(instructions())
 
-            elif action.lower() == "censor off":
-                if not generator.censor:
-                    console_print("Censor is already disabled.")
-                else:
-                    generator.censor = False
-                    console_print("Censor is now disabled.")
+                elif command == "censor":
+                    if args[0] == "off":
+                        if not generator.censor:
+                            console_print("Censor is already disabled.")
+                        else:
+                            generator.censor = False
+                            console_print("Censor is now disabled.")
 
-            elif action.lower() == "censor on":
-                if generator.censor:
-                    console_print("Censor is already enabled.")
-                else:
-                    generator.censor = True
-                    console_print("Censor is now enabled.")
+                    elif args[0] == "on":
+                        if generator.censor:
+                            console_print("Censor is already enabled.")
+                        else:
+                            generator.censor = True
+                            console_print("Censor is now enabled.")
 
-            elif action.lower() == "save":
-                if upload_story:
-                    id = story_manager.story.save_to_storage()
-                    console_print("Game saved.")
-                    console_print(
-                        "To load the game, type 'load' and enter the following ID: "
-                        + id
-                    )
-                else:
-                    console_print("Saving has been turned off. Cannot save.")
+                    else:
+                        console_print(f"Invalid argument: {args[0]}")
 
-            elif action.lower() == "load":
-                load_ID = input("What is the ID of the saved game?")
-                result = story_manager.story.load_from_storage(load_ID)
-                console_print("\nLoading Game...\n")
-                console_print(result)
+                elif command == "save":
+                    if upload_story:
+                        id = story_manager.story.save_to_storage()
+                        console_print("Game saved.")
+                        console_print(f"To load the game, type 'load' and enter the following ID: {id}")
+                    else:
+                        console_print("Saving has been turned off. Cannot save.")
 
-            elif len(action.split(" ")) == 2 and action.split(" ")[0].lower() == "load":
-                load_ID = action.split(" ")[1]
-                result = story_manager.story.load_from_storage(load_ID)
-                console_print("\nLoading Game...\n")
-                console_print(result)
+                elif command == "load":
+                    if len(args) == 0:
+                        load_ID = input("What is the ID of the saved game?")
+                    else:
+                        load_ID = args[0]
+                    result = story_manager.story.load_from_storage(load_ID)
+                    console_print("\nLoading Game...\n")
+                    console_print(result)
 
-            elif action.lower() == "print":
-                print("\nPRINTING\n")
-                print(str(story_manager.story))
+                elif command == "print":
+                    print("\nPRINTING\n")
+                    print(str(story_manager.story))
 
-            elif action.lower() == "revert":
+                elif command == "revert":
+                    if len(story_manager.story.actions) is 0:
+                        console_print("You can't go back any farther. ")
+                        continue
 
-                if len(story_manager.story.actions) is 0:
-                    console_print("You can't go back any farther. ")
+                    story_manager.story.actions = story_manager.story.actions[:-1]
+                    story_manager.story.results = story_manager.story.results[:-1]
+                    console_print("Last action reverted. ")
+                    if len(story_manager.story.results) > 0:
+                        console_print(story_manager.story.results[-1])
+                    else:
+                        console_print(story_manager.story.story_start)
                     continue
 
-                story_manager.story.actions = story_manager.story.actions[:-1]
-                story_manager.story.results = story_manager.story.results[:-1]
-                console_print("Last action reverted. ")
-                if len(story_manager.story.results) > 0:
-                    console_print(story_manager.story.results[-1])
                 else:
-                    console_print(story_manager.story.story_start)
-                continue
+                    console_print(f"Unknown command: {command}")
 
             else:
                 if action == "":


### PR DESCRIPTION
This makes it so that commands must start with a `/`, and splits the input by spaces to get arguments for commands.

My reasoning for choosing `/` specifically is because users (especially gamers) will be more familiar with using `/` to denote commands (eg minecraft)