### PR TITLE
Add basic EditorConfig

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,14 @@
+# Normalizes editor configuration.
+# http://editorconfig.org
+root = true
+
+[*]
+indent_style = space
+indent_size = 4
+end_of_line = LF
+charset = utf-8
+trim_trailing_whitespace = true
+insert_final_newline = true
+
+[*.md]
+trim_trailing_whitespace = false


### PR DESCRIPTION
As more people begin to contribute to this project, you may want an [`.editorconfig`](https://editorconfig.org/) file to keep basic formatting consistent.