### PR TITLE
Add install.sh Arch Linux support.

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -28,8 +28,8 @@ system_package_install() {
 		sudo yum install ${PACKAGES[@]}
 	elif is_command 'dnf'; then
 		sudo dnf install ${PACKAGES[@]}
-	elif is_command 'packman'; then
-		sudo packman -S ${PACKAGES[@]}
+	elif is_command 'pacman'; then
+		sudo pacman -S ${PACKAGES[@]}
 	elif is_command 'apk'; then
 		sudo apk --update add ${PACKAGES[@]}
 	else


### PR DESCRIPTION
Arch uses pacman and not packman. No distro that I am aware of uses packman and no tool named packman for managing linux packages exists.