### PR TITLE
Print current censor status

### DIFF
--- a/play.py
+++ b/play.py
@@ -192,7 +192,12 @@ def play_aidungeon_2():
                     console_print(instructions())
 
                 elif command == "censor":
-                    if args[0] == "off":
+                    if len(args) == 0:
+                        if generator.censor:
+                            console_print("Censor is enabled.")
+                        else:
+                            console_print("Censor is disabled.")
+                    elif args[0] == "off":
                         if not generator.censor:
                             console_print("Censor is already disabled.")
                         else:


### PR DESCRIPTION
Had expected `/censor` without an argument to print the current status, this implements that.

## 🧪 How to Test

1. `/censor` without arguments

## 📷 Screenshot (optional)

![image](https://user-images.githubusercontent.com/1044068/70940255-d8c56680-2041-11ea-9cda-8bf6cafd9f2a.png)

