### PR TITLE
Fix return value mismatch for custom setting

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - install.sh no longer tries calling `apt-get` on distributions without it.
 - Arch Linux now works with install.sh (with pyenv is used or python3.6 is set as python3).
 - A bug that caused game to crash if given an incorrect game ID to load.
+- Fixed bug preventing `Custom` game setting selection from working.
 
 ### Changed
 - Made `install.sh` more robust.

--- a/play.py
+++ b/play.py
@@ -91,6 +91,17 @@ def select_game():
     return setting_key, character_key, name, character, setting_description
 
 
+def get_custom_prompt():
+    context = ""
+    console_print(
+        "\nEnter a prompt that describes who you are and the first couple sentences of where you start "
+        "out ex:\n 'You are a knight in the kingdom of Larion. You are hunting the evil dragon who has been "
+        + "terrorizing the kingdom. You enter the forest searching for the dragon and see' "
+    )
+    prompt = input("Starting Prompt: ")
+    return context, prompt
+
+
 def get_curated_exposition(setting_key, character_key, name, character, setting_description):
     name_token = "<NAME>"
     if (
@@ -121,15 +132,6 @@ def get_curated_exposition(setting_key, character_key, name, character, setting_
 
     return context, prompt
 
-def get_custom_prompt():
-    context = ""
-    console_print(
-        "\nEnter a prompt that describes who you are and the first couple sentences of where you start "
-        "out ex:\n 'You are a knight in the kingdom of Larion. You are hunting the evil dragon who has been "
-        + "terrorizing the kingdom. You enter the forest searching for the dragon and see' "
-    )
-    prompt = input("Starting Prompt: ")
-    return context, prompt
 
 def instructions():
     text = "\nAI Dungeon 2 Instructions:"
@@ -180,6 +182,7 @@ def play_aidungeon_2():
 
                 if setting_key == "custom":
                     context, prompt = get_custom_prompt()
+
                 else:
                     context, prompt = get_curated_exposition(setting_key, character_key, name, character, setting_description)
 

--- a/play.py
+++ b/play.py
@@ -74,15 +74,7 @@ def select_game():
     choice = get_num_options(len(settings) + 1)
 
     if choice == len(settings):
-
-        context = ""
-        console_print(
-            "\nEnter a prompt that describes who you are and the first couple sentences of where you start "
-            "out ex:\n 'You are a knight in the kingdom of Larion. You are hunting the evil dragon who has been "
-            + "terrorizing the kingdom. You enter the forest searching for the dragon and see' "
-        )
-        prompt = input("Starting Prompt: ")
-        return context, prompt
+        return "custom", None, None, None, None
 
     setting_key = list(settings)[choice]
 
@@ -129,6 +121,15 @@ def get_curated_exposition(setting_key, character_key, name, character, setting_
 
     return context, prompt
 
+def get_custom_prompt():
+    context = ""
+    console_print(
+        "\nEnter a prompt that describes who you are and the first couple sentences of where you start "
+        "out ex:\n 'You are a knight in the kingdom of Larion. You are hunting the evil dragon who has been "
+        + "terrorizing the kingdom. You enter the forest searching for the dragon and see' "
+    )
+    prompt = input("Starting Prompt: ")
+    return context, prompt
 
 def instructions():
     text = "\nAI Dungeon 2 Instructions:"
@@ -176,7 +177,12 @@ def play_aidungeon_2():
             if splash_choice == "new":
                 print("\n\n")
                 setting_key, character_key, name, character, setting_description = select_game()
-                context, prompt = get_curated_exposition(setting_key, character_key, name, character, setting_description)
+
+                if setting_key == "custom":
+                    context, prompt = get_custom_prompt()
+                else:
+                    context, prompt = get_curated_exposition(setting_key, character_key, name, character, setting_description)
+
                 console_print(instructions())
                 print("\nGenerating story...")
 


### PR DESCRIPTION
## 🎉 Issues resolved:

- closes #185

## 🧪 How to Test

1. In Colab, change first lines of first code block from
```
# Install
!git clone --depth 1 --branch master https://github.com/AIDungeon/AIDungeon/
```
to
```
# Install
!git clone --depth 1 --branch develop https://github.com/LEDCoyote/AIDungeon/
```
2. Run "Install", "Download", and "Play" blocks in sequence.
3. When prompted select "New Game" (0)
4. Random Story: No (1)
5. Setting: Custom (4)
6. Enter a prompt and verify that the error expecting 5 return values but got 2 was not produced.
