### PR TITLE
Added soft restart command, old restart renamed

### DIFF
--- a/play.py
+++ b/play.py
@@ -142,7 +142,8 @@ def instructions():
     text += "\n\nThe following commands can be entered for any action: "
     text += '\n  "/revert"   Reverts the last action allowing you to pick a different action.'
     text += '\n  "/quit"     Quits the game and saves'
-    text += '\n  "/restart"  Starts a new game and saves your current one'
+    text += '\n  "/reset"    Starts a new game and saves your current one'
+    text += '\n  "/restart"  Starts the game from beginning with same settings'
     text += '\n  "/save"     Makes a new save of your game and gives you the save ID'
     text += '\n  "/load"     Asks for a save ID and loads the game if the ID is valid'
     text += '\n  "/print"    Prints a transcript of your adventure (without extra newline formatting)'
@@ -220,7 +221,7 @@ def play_aidungeon_2():
                 split = action[1:].split(" ")  # removes preceding slash
                 command = split[0].lower()
                 args = split[1:]
-                if command == "restart":
+                if command == "reset":
                     while True:
                         try:
                             rating = input("Please rate the story quality from 1-10: ")
@@ -231,6 +232,13 @@ def play_aidungeon_2():
                             story_manager.story.rating = rating_float
                             break
                     break
+                    
+                if command == "restart":
+                    story_manager.story.actions = []
+                    story_manager.story.results = []
+                    console_print("Game restarted.")
+                    console_print(story_manager.story.story_start)
+                    continue
 
                 elif command == "quit":
                     while True:


### PR DESCRIPTION
As proposed in #194, two kinds of restart implemented, `soft`, which just reverts any action and reaction, and `hard` with relaunch-like functionality.
Soft restart called `restart`, while hard one is renamed to `reset`.
Rating functionality is removed from soft restart, because rating shouldn't stick with basically a completely new story.

## 🎉 Issues resolved:

- closes #194 

## 🧪 How to Test

1. Start a new story, play a little
2. Type in `/restart`, game should start again with the same settings
3. Play a little
4. Type in `/reset`, game should start as if you've just launched it 

<!-- 

## 📷 Screenshot (optional)

-->
