### PR TITLE
Added 'The rest is history...' victory condition.

### DIFF
--- a/story/utils.py
+++ b/story/utils.py
@@ -73,6 +73,7 @@ def player_won(text):
         "you ((\w* )*and |)((go|get) (in)?to|arrive (at|in)) (heaven|paradise)",
         "you ((\w* )*and |)celebrate your (victory|triumph)",
         "you ((\w* )*and |)retire",
+        "The rest is history...",
     ]
     return any(re.search(regexp, lower_text) for regexp in won_phrases)
 


### PR DESCRIPTION
'The rest is history...' is a fairly frequently terminating condition for stories. Without this PR the player is left 'stuck', unable to advance the narrative but without having won or lost.

There is a question is to whether this is truly a 'winning' condition or whether (in the absence of the model proclaiming victory/death) this should rather trigger a neutral ending of some kind.